### PR TITLE
Remove ugly redirect from production and staging

### DIFF
--- a/_s3_prod_config/s3_website.yml
+++ b/_s3_prod_config/s3_website.yml
@@ -31,6 +31,7 @@ exclude_from_upload:
     - Gemfile.lock
     - .bundle
     - vendor
+    - ^index.html$
 
 redirects:
   index.html: blog/

--- a/_s3_stage_config/s3_website.yml
+++ b/_s3_stage_config/s3_website.yml
@@ -25,6 +25,7 @@ exclude_from_upload:
     - Gemfile.lock
     - .bundle
     - vendor
+    - ^index.html$
 
 redirects:
   index.html: blog/


### PR DESCRIPTION
Note that the index file has been preserved in order to ensure that local development sites still work correctly
