### PR TITLE
Update header hierarchy

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -110,10 +110,9 @@ html {
  }
 
  h3 {
- 	font-family: 'HelveticaNeue-Bold';
+ 	font-family: 'HelveticaNeue';
+ 	font-size: 26px;
  	color: #000000;
- 	line-height: 28px;
- 	font-size: 32px;
  	line-height: 28px;
  }
 

--- a/blog/cloud-computing/_posts/2015-08-11-cloud-youre-doing-it-wrong.markdown
+++ b/blog/cloud-computing/_posts/2015-08-11-cloud-youre-doing-it-wrong.markdown
@@ -53,7 +53,7 @@ If you aren’t thinking about cloud in this manner then you are simply doing it
 
 
 
-# A Recent Example
+## A Recent Example
 
 
 

--- a/blog/cloud-computing/_posts/2016-05-17-will-containers-replace-hypervisors-almost-certainly.markdown
+++ b/blog/cloud-computing/_posts/2016-05-17-will-containers-replace-hypervisors-almost-certainly.markdown
@@ -16,7 +16,7 @@ Finally, what is OpenStack’s place in this?  Unlike ESX, OpenStack isn’t a h
 
 Let’s discuss.
 
-# Containers as Infrastructure vs. Containers as Application-centric Packaging and Management Tools
+## Containers as Infrastructure vs. Containers as Application-centric Packaging and Management Tools
 
 Perhaps I will talk more about this in future, but it’s important to understand that, unlike VMs, containers have a dual lens you can view them through: are they infrastructure (aka “lightweight VMs”) or are they application management and configuration systems?  The reality is that they are both.  If you are an infrastructure person you likely see them as the former and if a developer you likely see them as the latter.
 
@@ -24,7 +24,7 @@ This points to a de facto path to flattening some parts of the cloud stack and t
 
 For this blog posting, I’m looking at containers primarily through the lens of being an infrastructure tool.
 
-# When Hypervisors Died
+## When Hypervisors Died
 
 The death knell of the hypervisor was sounded when Intel provided much of the unique capabilities of the hypervisor directly in the chip via the [Intel-VTx](https://en.wikipedia.org/wiki/X86_virtualization) instruction set.  Prior to this, VMware and Xen had two unique approaches to providing hypervisor capabilities: binary translation and paravirtualization respectively.  Arguments raged about which was faster, but once Intel-VTx came along, by virtue of being on the chip die, it was the de facto speed winner.  After that, VMware ESX and Xen both used Intel-VTx by default.  This also allowed the creation of KVM which depends 100% on the Intel-VTx chipset for these capabilities.  Perhaps most importantly, it negated most of the differences between "type-1" and "type-2" hypervisors.
 
@@ -32,7 +32,7 @@ Now, of course, you could argue, that hypervisors still provide value, but this 
 
 Let me explain.
 
-## The Paravirtualization Driver Layer in Hypervisors
+### The Paravirtualization Driver Layer in Hypervisors
 
 Once Intel-VTx came about, the big problem for managing existing legacy “pet” workloads was supporting a wide variety of operating systems.  This is what exists in enterprise environments today and support for heterogeneous environments is critical to supporting them.  Unfortunately, while you can run an unmodified kernel on Intel-VTx, system calls that touch networking and disk still wind up hitting emulated hardware.  Intel-VTx primarily solved the issues of segregating, isolating, and allowing high performance access to direct CPU calls and memory access (via [Extended Page Table [EPT]](https://en.wikipedia.org/wiki/Second_Level_Address_Translation)).  Intel-VT does not solve access to network and disk, although SR-IOV, VT-d, and related attempted to address this issue, but never quite got there. [1]
 
@@ -46,7 +46,7 @@ Most importantly, at this point, the hypervisors themselves are really just a la
 
 And one has to ask: “For how long will we have heterogeneous operating systems in the enterprise datacenter?”
 
-# The Homogenization of the Enterprise Datacenter Means Containers Win Ultimately
+## The Homogenization of the Enterprise Datacenter Means Containers Win Ultimately
 
 As we move towards cloud native applications and the third platform, we are all keenly aware of the need to standardize and normalize the underlying operating systems.  You can’t get greater operational efficiency if you are running 20 different operating systems.  If you desire containers, then you are also looking at running them on homogeneous or mostly homogeneous environments.  If you are moving to any kind of PaaS platform, you are standardizing the underlying operating systems.  Everywhere you look, we're moving away from heterogeneity.[3]
 
@@ -56,7 +56,7 @@ The primary argument for the hypervisor is around supporting pet workloads that 
 
 Unfortunately for the hypervisor, all of this is coming to fruition in container land one way or another.  Except perhaps heterogeneity, which is simply becoming a non-issue.
 
-## Containers and Security
+### Containers and Security
 
 It’s a popular refrain to talk about containers as being “less secure” than hypervisors, despite the fact that for some of us, containers were originally conceived as an application security mechanism.  They allow packaging up an application into a very low attack surface, running it as an unprivileged user, in an isolated jail![4]  That’s far better than a typical VM-based approach where you lug along most of an operating system that has to be patched and maintained regularly.
 
@@ -66,13 +66,13 @@ You can expect Intel to continue to enrich the Intel-VTx instruction set and for
 
 Combined with removing most of the operating system wrapped arbitrarily around the application in a hypervisor VM, containers may actually already be *more* secure than the hypervisor model.  But we can say for certain that given time this will certainly be true.
 
-## Containers and Resiliency
+### Containers and Resiliency
 
 We then must ask the question: “what about DRS and HA?”  Taking aside the fact that these capabilities are largely about supporting pet workloads and that containers don’t play in this world, the reality is that DRS and HA are largely unnecessary in an elastic third platform world.  Platform-as-a-Service (PaaS) tools like [Cloud Foundry](http://www.cloudfoundry.org), container management systems like [Kubernetes](http://kubernetes.io/), [Rancher](http://www.rancher.com), [Mesos](http://mesos.apache.org/), and similar management tools are already designed to dynamically scale your workloads.  They detect performance and failure issues within your running application and take proactive steps to deal with them.
 
 This then leads us to understand that hypervisors sole value resides primarily around supporting many operating systems using PV drivers, something that is not a requirement in the next generation datacenter.
 
-# The Change in Pictures
+## The Change in Pictures
 
 To help you grok what this change might look like, here’s a view of what the end game is, which assumes that hypervisors “win” in the second platform and are a key tool for supporting legacy workloads, while containers “win” in the third platform for cloud native applications, and become the primary tool to enable modern datacenters and their workloads.
 
@@ -89,7 +89,7 @@ This third point is worth going into a bit more detail on.  It will require a fu
 
 I think it's certainly worth consideration that hypervisors and "pet" type mentality drag us into making overwrought, complex infrastructure topologies that are simply unnecessary for modern applications.
 
-# OpenStack + Containers or OpenStack vs. Containers?
+## OpenStack + Containers or OpenStack vs. Containers?
 
 For some, there is a question of whether cloud native applications and modern datacenters are dominated by OpenStack or the container ecosystem.  For others, these systems work together.   There are equally good arguments on either side.  On one hand, OpenStack can look like a complex, overwrought attempt at ocean boiling for Infrastructure-as-a-Service (IaaS).  On the other, there is no other ecosystem that is as comprehensive, including DNS services, networking services, storage, VMs, bare metal, containers, database services, key management, and so on.
 
@@ -97,7 +97,7 @@ Things might be further confused in that if you look at the [primary “PaaS” 
 
 A go forward path that already looks like it’s happening is that hypervisors and containers coexist in the short to medium term, but that as time goes on, the stack flattens and we begin running containers directly on bare metal systems, cutting the hypervisor out, simplifying the stack, while providing greater security, availability, and performance.  Ultimately we wind up with a picture that looks like above.
 
-# The Ship Has Sailed
+## The Ship Has Sailed
 
 From my viewpoint, the ship has sailed on hypervisors.  It’s now a container world for the next generation of cloud native applications and it’s only a matter of time before we get there.  In the meantime, running containers on top of virtualization substrates is a common way to “just get started”, while the underlying technologies get better and better at running containers directly on bare metal.  The modern datacenter will be relatively homogeneous, just like the web scale companies who brought us cloud computing.  It will host predominantly cloud-native applications which will manage their own resiliency using platforms like Cloud Foundry, and it will be more secure and higher performance, with much greater levels of utilization, than ever before primarily due to the trajectory of containers and their ecosystem.
 

--- a/blog/openstack/_posts/2016-04-21-the-ranchers-dilemma.markdown
+++ b/blog/openstack/_posts/2016-04-21-the-ranchers-dilemma.markdown
@@ -18,7 +18,7 @@ Before I do though, let me say that pets vs cattle is still alive and well. As I
 
 Still time marches on and I want to share why it is ultimately possible to cross the streams. Let's also discuss what remains to get to a place where we can all become ranchers, incorporating pets, cattle, and perhaps children onto a single farm/ranch/infrastructure that can accommodate a variety of generational IT workloads.
 
-# Background: The Three Platforms
+## Background: The Three Platforms
 
 In order to understand the rest of this blog posting, you need to wrap your head around the generational shift in IT patterns that IDC outlined and called the First, Second, and Third Platforms:
 
@@ -30,7 +30,7 @@ Here’s a diagram that covers enough of a subset of characteristics as to make 
 
 ![Characteristics of the Three Platforms](/assets/media/2016/cloud-computing-patterns-are-different.jpeg)
 
-# Differing Generational IT Workload Requirements
+## Differing Generational IT Workload Requirements
 
 Although there are many differences between the second and third platforms, I believe the pets vs cattle meme has been as successful as it has because it highlights the biggest difference: servers as a disposable, commodity item. No identity and low or no cost. Treating servers like electrical amps, data packets, cellular minutes, oil, gas, or anything else that is a true commodity.
 
@@ -50,7 +50,7 @@ Is it possible to have a modern, inexpensive, software-centric infrastructure sy
 
 Certainly! Although not all of the elements are there today.  Some are though and the quality of those components has increased dramatically in the past year or so.
 
-# Storage Tools & Technology for the Modern Cloud Rancher
+## Storage Tools & Technology for the Modern Cloud Rancher
 
 A key tool for those trying to enable “cloud ranchers” is “live migration”. The ability to move a virtual machine or possibly container between hosts without impacting the running workload. This requires a shared storage system that was traditionally provided by a complex and expensive fiber channel SAN (FC-SAN). More modern approaches like [ScaleIO](https://www.emc.com/storage/scaleio/index.htm), VSAN, and Ceph provide so-called [“server SANs”](http://wikibon.org/wiki/v/The_Rise_of_Server_SAN) that replace FC-SANs with a software-centric scale-out model running on top of generic commodity servers.
 
@@ -60,13 +60,13 @@ Some of these technology gaps are able to be overcome and some are not. Certain 
 
 Today’s OpenStack deployments can support live migration if they use ScaleIO or Ceph as the underlying storage substrate.  More importantly, these software-centric storage systems can run on top of generic commodity storage and drive the relative cost of storage towards zero.  In effect, providing different infrastructure value propositions for legacy or cloud-native applications.  Some, like ScaleIO, even have the [performance of FC-SANs and can provide equivalent performance to modern all flash arrays](/blog/cloud-computing/killing-the-storage-unicorn-purpose-built-scaleio-spanks-multi-purpose-ceph-on-performance/).
 
-# We Aren’t There Yet
+## We Aren’t There Yet
 
 I’ve only touched on storage here and very lightly on compute. There are a number of other gaps that need to be filled before you can succeed at running pets and cattle applications on the same system. For example, the scheduling system(s) in OpenStack aren’t where they can replicate [VMware DRS and HA](https://pubs.vmware.com/vsphere-50/index.jsp?topic=%2Fcom.vmware.wssdk.pg.doc_50%2FPG_Ch13_Resources.15.6.html). Even when that happens, you would need to enable the capability selectively per application, since providing DRS and HA to cattle applications is a bad idea. [3]
 
 The point is that we’re starting to see the window open on delivering a unified infrastructure system that enables us to support pets and cattle simultaneously.
 
-# Getting a Taste of the Future
+## Getting a Taste of the Future
 
 If you are in Austin, TX next week for the OpenStack Summit, myself and some EMC colleagues are going to demonstrate the live migration of a pet-based workload (Oracle) running on top of OpenStack with ScaleIO as an underlying substrate.  We will show live migrating a massive Oracle database server (64GB RAM) with little or no impact to overall storage system throughput (~10% or less) running on a hyperconverged OpenStack cluster (migration network and storage network are shared).
 
@@ -77,9 +77,8 @@ Here are the [details](https://www.openstack.org/summit/austin-2016/summit-sched
 | Presentation Title | Using ScaleIO in an OpenStack Environment |
 | Date & Time | Monday, April 25, 3:40pm-4:20pm |
 | Location | Austin Convention Center - Level 4 - MR 18 A/B |
-| | |  
   
-# Wrapping Up
+## Wrapping Up
 
 It’s just a matter of time before pets and cattle are reconciled by cloud ranchers. In the meantime, check yourself before you wreck yourself. Trying to cross the streams is still a top cause for failures. There are no panaceas in IT.  I guarantee you won’t see scale-out, high performance, SRDF any time soon. You are always making tradeoffs. It just so happens that sometimes we can make tradeoffs that accommodate more than one master.
 

--- a/blog/openstack/_posts/2016-05-10-you-are-locked-in-deal-with-it.markdown
+++ b/blog/openstack/_posts/2016-05-10-you-are-locked-in-deal-with-it.markdown
@@ -12,7 +12,7 @@ You don't want lock-in?  Great.  Find another universe.  In this universe everyo
 
 Here's what you *really* want: control.  Let me explain.
 
-# Debunking the No-Lock-In Myth
+## Debunking the No-Lock-In Myth
 
 Open source can't save you.  You're locked in.  Don't believe me?  Using RedHat?  It's open source.  Try switching to SUSE or Ubuntu across your enterprise.  Right.  It won't happen.  Or, more accurately, it won't happen easily.  Because switching from RedHat means you have to deal with all of these issues:
 
@@ -31,7 +31,7 @@ How do you retain control?
 
 It must be possible to switch to a new system/product/platform and this is why open source can seem like a compelling solution.
 
-# Switching Cost Reduction: The True Lever We All Need
+## Switching Cost Reduction: The True Lever We All Need
 
 Whether you're EMC or another business, what you're looking for in open source isn't really no lock-in, it's reducing switching costs.  Open source at least gives you the option of switching.  It's hard (per my examples above), but doable.  Being doable means you have a big lever you can use against the vendors who support you.  It means you get to invert the relationship between buyer and vendor such the buyer has the power, as it should be.  This is similar to what Apple did in [inverting the power dynamics with the carriers](https://archive.wired.com/gadgets/wireless/magazine/16-02/ff_iphone?currentPage=all).  It's also similar to what the [Open Compute Project](http://opencompute.org) hopes to achieve.
 
@@ -39,7 +39,7 @@ In fact, this is fundamentally at the heart of what is necessary for your busine
 
 There are also a few other things that are desirable, but not nearly as large of an imperative.
 
-## Open Source's Contribution to "Control"
+### Open Source's Contribution to "Control"
 
 While reducing switching costs is the primary vehicle to controlling the relationship to the vendor, open source, specifically, provides a couple of other big values:
 
@@ -50,11 +50,11 @@ The ability to influence the roadmap is important.  Not nearly as important as i
 
 Community means having other businesses like you around the table, with the same stake, and an interest in seeing the community-driven project made to work for all.  It also means that if you are having problems, it's more likely that someone else like you in the community is seeing the same things and you can share notes and work on the issues together, rather than being dependent on a vendor and their support team.
 
-# The Vendor Power Dynamic is Inverting ... Period
+## The Vendor Power Dynamic is Inverting ... Period
 
 Customers want the power dynamic with their vendors to change.  "Oracle" is a four-letter word inside the enterprise.  Enterprise software vendors who insist on maintaining lock-in of their customer base are going to be surprised as the power dynamic shifts.  Let me be clear here.  I believe it is no longer a case of "if" but "when".  Many enterprises are [switching to an "open source first" strategy](http://reflectionsblog.emc.com/open-source-first-strategy/).  I see this more and more as I talk to businesses and I don't think this is a "pendulum swing".  I think it's a permanent change in perspective.
 
-## But is Open Source Really Required to Change the Vendor Dynamic?
+### But is Open Source Really Required to Change the Vendor Dynamic?
 
 One thing I find startling though, is the over reliance on open source to change this dynamic.  You all know I'm a big fan of open source, yet building great business models around it is still something we're learning.[2]  The world's greatest open source software won't be written for "free".  Someone has to fund it.  Community efforts like [OpenStack](http://www.openstack.org) are a agglomeration of businesses deriving value from open source while also monetizing it.  So open source has to be written by someone and that someone needs a pay check.
 
@@ -70,13 +70,13 @@ It also means that enterprise software businesses might be able to build compell
 
 That's good for everyone.
 
-# A Brief Aside on The "Other" Open Source Software Model
+## A Brief Aside on The "Other" Open Source Software Model
 
 I'll blog about this soon, but there is another open source software model.  You can run it as software as a *aaS company.  Most prominent of these are companies like Amazon and Google.  Running open source as a service means you are usually buying into a walled garden, in other words, another form of lock-in.  I thought you went to open source to "avoid lock-in" and maintain control?  Why are you suddenly in such a hurry to cede control?  This model for open source is why people like Richard Stallman started freaking out and why the [Affero GPL (AGPL)](http://www.gnu.org/licenses/why-affero-gpl.en.html) was created.  This isn't a new issue.
 
 More soon.
 
-# Do You Hear Me?
+## Do You Hear Me?
 
 Let me run it down as clearly as possible.
 

--- a/blog/openstack/_posts/2016-07-12-unlocked-openstack-plus-scaleio.md
+++ b/blog/openstack/_posts/2016-07-12-unlocked-openstack-plus-scaleio.md
@@ -6,6 +6,7 @@ author: Randy Bias
 date: 2016-07-12 16:33:37
 
 ---
+
 For the past few months an elite team of Cloudscalers (EMCers) have been working diligently on making [ScaleIO](https://www.emc.com/storage/scaleio/index.htm) great in OpenStack-land.  ScaleIO "supported" OpenStack, but it might take a fair bit of time and energy to get it setup.  No longer.  As of last Friday, both Mirantis OpenStack and Canonical OpenStack work with ScaleIO at the push of a button.  The free and frictionless[1]  version of ScaleIO can be automatically installed for these OpenStack distributions and at any time you can upgrade your free & frictionless installation to a fully supported commercial version of ScaleIO.
 
 This work was done by coordinating carefully with our partners, writing a bunch of plugin and recipe code, feedback from customers, and testing, testing, testing.
@@ -16,11 +17,11 @@ There are several key areas of work:
 2. Canonical integration by building Juju Charms based on the Puppet recipes above
 3. Mirantis integration by creating Fuel plugins for ScaleIO, which also leverage Puppet recipes as required
 
-# ScaleIO Puppet Recipes
+## ScaleIO Puppet Recipes
 
 At the heart of much of the work is a set of Puppet recipes to configure and install ScaleIO and OpenStack.  There are two sets of work: *[puppet-scaleio](https://github.com/emccode/puppet-scaleio)* for ScaleIO and *[puppet-scaleio-openstack](https://github.com/emccode/puppet-scaleio-openstack)* for the configuration of OpenStack for managing ScaleIO.
 
-## Supported Configurations
+### Supported Configurations
 
 These two sets of recipes together support:
 
@@ -29,7 +30,7 @@ These two sets of recipes together support:
 * Deploying and operating ScaleIO in a hyperconverged or "2-layer" configuration[2] 
 * Ubuntu 14.04 LTS[3] 
 
-## puppet-scaleio
+### puppet-scaleio
 
 This Puppet recipe configures and manages ScaleIO.
 
@@ -46,7 +47,7 @@ And was tested with all of the following:
 * Ubuntu 14.04 LTS
 * Linux kernel 4.2.0-30-generic and 3.13.0-*-generic
 
-## puppet-scaleio-openstack
+### puppet-scaleio-openstack
 
 This Puppet recipe configures and manages OpenStack to work with ScaleIO.
 
@@ -67,7 +68,7 @@ And was tested with all of the following:
 * Linux kernel 4.2.0-30-generic and 3.13.0-83-generic
 * OpenStack Juno, Kilo, Liberty
 
-# Canonical OpenStack and ScaleIO
+## Canonical OpenStack and ScaleIO
 
 Juju is a state of the art, open source service modelling tool used with Ubuntu Server and Canonical OpenStack to manage your datacenter. Juju allows you to model, configure, manage, maintain, deploy and scale cloud services quickly and efficiently. It makes Canonical OpenStack easy for customers to deploy and automates many manual steps.
 
@@ -77,7 +78,7 @@ The following configuration is tested and supported:
 
 * Canonical OpenStack Liberty with ScaleIO 2.0 running on Ubuntu 14.04 LTS
 
-# Mirantis OpenStack and ScaleIO
+## Mirantis OpenStack and ScaleIO
 
 Mirantis OpenStack depends on Fuel, an open-source deployment and lifecycle management engine. It makes Mirantis OpenStack easy for customers to deploy in optimal configurations on a wide range of generic x86 servers and network hardware. It automates manual steps that might otherwise require great familiarity with OpenStack and hours or days of engineering time; as well as has a simple UI and can auto-discover servers and storage components.
 
@@ -87,7 +88,7 @@ The following configurations have been tested and validated by both Cloudscalers
 
 * Mirantis OpenStack versions 6.1, 7.0 and 8.0 with ScaleIO 2.0 running on Ubuntu 14.04 LTS
 
-# Minor Differences Between Distributions
+## Minor Differences Between Distributions
 
 There are minor differences in support of the various distributions based on constraints of those systems themselves.  Meaning that while we support a fairly robust set of options for configuration with the Puppet recipes, not all options may be available in Canonical or Mirantis.  We will work to close this gap over time.
 
@@ -131,7 +132,7 @@ MOS9.0 for FUEL. |
 | Volumes size granularity is 8GB | + | + | For persistent volumes volume sizes are rounded by 8GB automatically, it could be forbidden via config file. |
 | Live instance migration | + | + |  |
 
-# Making ScaleIO Great in OpenStack (Again?)
+## Making ScaleIO Great in OpenStack (Again?)
 
 This is the beginning of driving greater ScaleIO adoption in OpenStack land.  As a reminder, ScaleIO is a much easier to operate and scale version of Ceph RBD.  It is usually in the range of [7-10x faster](http://cloudscaling.com/blog/cloud-computing/killing-the-storage-unicorn-purpose-built-scaleio-spanks-multi-purpose-ceph-on-performance/) (sometimes **much** faster than this, depending on configuration or workload).  EMC is finding that our some of our best ScaleIO customers are those who have been ground up on the shoals of the [Ceph cloud-wrecking reef](https://www.emc.com/collateral/white-papers/h14872-the-case-for-tiered-storage-in-the-enterprise.pdf).  Hopefully this program makes it easier for adopters of OpenStack to [perform their own bake off between ScaleIO and Ceph](https://www.emc.com/video-collateral/demos/microsites/mediaplayer-video/battle-of-the-titans-tokyo-2015.htm) and helps make a better decision sooner in your OpenStack journey.
 
@@ -141,4 +142,3 @@ Meanwhile, we’re working on better integration to Red Hat OpenStack, updates f
 [2]  Hyper-converged configurations mean that the storage and compute run together on the same server(s) where a 2-layer configuration refers to a more traditional SAN architecture where storage runs on dedicated nodes and is connected to the compute that consumes it via a network  
 [3]  Other flavors of Ubuntu and other Linux distributions will be tested in the near future  
 [4]  That means support for KVM live migration just as we have in the VxRack Neutrino system  
-


### PR DESCRIPTION
Make a clearer distinction between the H2 and H3 in CSS.

Update recent posts to ensure that the content starts with
an H2, because the H1 is reserved for the post title.
